### PR TITLE
Added document ID to every synced document.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -58,10 +58,17 @@ var PiniaFirestoreSync = function (_a) {
         // Document
         if (ref instanceof firestore_1.DocumentReference) {
             return (0, firestore_1.onSnapshot)(ref, function (ds) { return __awaiter(void 0, void 0, void 0, function () {
+                var data;
                 var _a;
                 return __generator(this, function (_b) {
                     if (ds.exists()) {
-                        store.$patch((_a = {}, _a[key] = ds.data(), _a));
+                        data = ds.data();
+                        Object.defineProperty(data, 'id', {
+                            value: ds.id,
+                            writable: false,
+                            enumerable: false
+                        });
+                        store.$patch((_a = {}, _a[key] = data, _a));
                     }
                     return [2 /*return*/];
                 });
@@ -71,7 +78,15 @@ var PiniaFirestoreSync = function (_a) {
         return (0, firestore_1.onSnapshot)(ref, function (qs) { return __awaiter(void 0, void 0, void 0, function () {
             var datum;
             return __generator(this, function (_a) {
-                datum = qs.docs.map(function (d) { return d.data(); });
+                datum = qs.docs.map(function (d) {
+                    var data = d.data();
+                    Object.defineProperty(data, 'id', {
+                        value: d.id,
+                        writable: false,
+                        enumerable: false
+                    });
+                    return data;
+                });
                 store.$patch(function (state) {
                     state[key] = datum;
                 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,28 @@ export const PiniaFirestoreSync = ({ store }: PiniaPluginContext) => {
     if (ref instanceof DocumentReference) {
       return onSnapshot(ref, async (ds) => {
         if (ds.exists()) {
-          store.$patch({ [key]: ds.data() })
+          const data = ds.data()
+          Object.defineProperty(data, 'id', {
+            value: ds.id,
+            writable: false,
+            enumerable:false
+          })
+          store.$patch({ [key]: data })
         }
       })
     }
 
     // Collection or Query
     return onSnapshot(ref, async (qs) => {
-      const datum = qs.docs.map(d => d.data())
+      const datum = qs.docs.map(d => {
+        const data = d.data()
+        Object.defineProperty(data, 'id', {
+          value: d.id,
+          writable: false,
+          enumerable:false
+        })
+        return data
+      })
       store.$patch((state) => {
         state[key] = datum
       })


### PR DESCRIPTION
It's required to have the document ID of the document for making updates in the Firestore database to a specific document.
This pull request adds the documents ID as a non-writable and non-enumerable property of every synced document.

**Non Writable:**
No chance of accidentally overwriting the ID - it shouldn't ever change.

**Non Enumerable:**
Dumping the document to DOM won't show the ID (preserving current behaviour):
```vue
<p>{{myDocument}}</P
```
But still enables access to the ID when it's needed with
```js
myDocument.id
```

This is a required feature in my opinion.