### PR TITLE
Fix removed fields in Firestore not propagating to state (Issue #5)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,9 @@ export const PiniaFirestoreSync = ({ store }: PiniaPluginContext) => {
             writable: false,
             enumerable:false
           })
-          store.$patch({ [key]: data })
+          store.$patch((state) => {
+            state[key] = data
+          })
         }
       })
     }


### PR DESCRIPTION
As mentioned in the #5, store.$patch({ [key]: data }) just merges new data onto the key (similar to `Object.extend` I suppose). Use the function syntax to access the state allows us to entirely replace the data with the new data which will then remove any newly removed fields.

Query and Collection sync's already did this.